### PR TITLE
add support for pod scheduling specs

### DIFF
--- a/helm/charts/td-agent-barito/templates/daemonset.yaml
+++ b/helm/charts/td-agent-barito/templates/daemonset.yaml
@@ -42,3 +42,18 @@ spec:
         - name: td-agent-barito-config
           configMap:
             name: {{ template "td-agent-barito.fullname" . }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/helm/charts/td-agent-barito/templates/daemonset.yaml
+++ b/helm/charts/td-agent-barito/templates/daemonset.yaml
@@ -42,17 +42,14 @@ spec:
         - name: td-agent-barito-config
           configMap:
             name: {{ template "td-agent-barito.fullname" . }}
-
       {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
       {{- end }}
-
       {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
       {{- end }}
-
       {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/helm/charts/td-agent-barito/values.yaml
+++ b/helm/charts/td-agent-barito/values.yaml
@@ -3,6 +3,8 @@ image:
   tag: 0.2.8
   pullPolicy: Always
 tolerations: []
+nodeSelector: {}
+affinity: {}
 
 rbac:
   ## If true, create and use RBAC resources


### PR DESCRIPTION
an example use case is when running in a multi-tenant cluster and there's a need to restrict the agent pods to specific node pools