### PR TITLE
add default app options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,18 @@ helm repo add barito https://baritolog.github.io/helm-charts
 2. Create a custom yaml containing helm chart values to specify app that you want its logs to be forwarded, example:
 ```yaml
 # myApps.yaml
+defaultAppOptions:
+  applicationGroupSecret: abc
+  produceUrl: https://barito-router.my-domain.com/produce_batch
 apps:
   - name: my-app-1
-    applicationGroupSecret: abc
     baritoAppName: My App 1
-    produceUrl: https://barito-router.my-domain.com/produce_batch
   - name: my-app-2
-    applicationGroupSecret: def
     baritoAppName: My App 2
-    produceUrl: https://barito-router.my-domain.com/produce_batch
+  - name: my-app-3
+    baritoAppName: My App 3
+    applicationGroupSecret: xyz
+    produceUrl: https://barito-router.other-domain.com/produce_batch
 ```
 
 > `name` is metadata name of your deployment

--- a/helm/charts/td-agent-barito/templates/tdagentbaritoconfig.yaml
+++ b/helm/charts/td-agent-barito/templates/tdagentbaritoconfig.yaml
@@ -27,19 +27,16 @@ data:
       @type barito_batch_k8s
       name {{ .name }}
       application_name {{ .baritoAppName }}
-
       {{- if .applicationGroupSecret }}
       application_group_secret {{ .applicationGroupSecret }}
       {{- else }}
       application_group_secret {{ $.Values.defaultAppOptions.applicationGroupSecret }}
       {{- end }}
-
       {{- if .produceUrl }}
       produce_url {{ .produceUrl }}
       {{- else }}
       produce_url {{ $.Values.defaultAppOptions.produceUrl }}
       {{- end }}
-
       <buffer>
         flush_at_shutdown {{ $.Values.defaultAgentOptions.buffer.flushAtShutdown }}
         flush_thread_count {{ $.Values.defaultAgentOptions.buffer.flushThreadCount }}

--- a/helm/charts/td-agent-barito/templates/tdagentbaritoconfig.yaml
+++ b/helm/charts/td-agent-barito/templates/tdagentbaritoconfig.yaml
@@ -26,9 +26,20 @@ data:
     <match kubernetes.var.log.containers.{{ .name }}-**.log>
       @type barito_batch_k8s
       name {{ .name }}
-      application_group_secret {{ .applicationGroupSecret }}
       application_name {{ .baritoAppName }}
+
+      {{- if .applicationGroupSecret }}
+      application_group_secret {{ .applicationGroupSecret }}
+      {{- else }}
+      application_group_secret {{ $.Values.defaultAppOptions.applicationGroupSecret }}
+      {{- end }}
+
+      {{- if .produceUrl }}
       produce_url {{ .produceUrl }}
+      {{- else }}
+      produce_url {{ $.Values.defaultAppOptions.produceUrl }}
+      {{- end }}
+
       <buffer>
         flush_at_shutdown {{ $.Values.defaultAgentOptions.buffer.flushAtShutdown }}
         flush_thread_count {{ $.Values.defaultAgentOptions.buffer.flushThreadCount }}

--- a/helm/charts/td-agent-barito/values.yaml
+++ b/helm/charts/td-agent-barito/values.yaml
@@ -18,10 +18,6 @@ resources:
   requests:
     memory: 512Mi
 
-defaultAppOptions:
-  applicationGroupSecret: null
-  produceUrl: null
-
 defaultAgentOptions:
   buffer:
     flushAtShutdown: false

--- a/helm/charts/td-agent-barito/values.yaml
+++ b/helm/charts/td-agent-barito/values.yaml
@@ -18,6 +18,10 @@ resources:
   requests:
     memory: 512Mi
 
+defaultAppOptions:
+  applicationGroupSecret: null
+  produceUrl: null
+
 defaultAgentOptions:
   buffer:
     flushAtShutdown: false


### PR DESCRIPTION
This PR adds ability to specify defaults for following common app options:

- applicationGroupSecret
- produceUrl

## sample use case

Especially for the secret option, it allows easy separation of config into multiple value files. For example we can have both "values.yaml" and "values-secrets.yaml" that stored with different access privileges.