### PR TITLE
update td-agent to v4 and split docker build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,17 @@ RUN ulimit -n 100000
 # Disable prompts from apt.
 ENV DEBIAN_FRONTEND noninteractive
 
-COPY build.sh /tmp/build.sh
-RUN ["chmod", "+x", "/tmp/build.sh"]
-RUN /tmp/build.sh
+COPY install.sh /tmp/install.sh
+RUN ["chmod", "+x", "/tmp/install.sh"]
+RUN /tmp/install.sh
+
+COPY config.sh /tmp/config.sh
+RUN ["chmod", "+x", "/tmp/config.sh"]
+RUN /tmp/config.sh
+
+COPY config.sh /tmp/cleanup.sh
+RUN ["chmod", "+x", "/tmp/cleanup.sh"]
+RUN /tmp/cleanup.sh
 
 ENV LD_PRELOAD /opt/td-agent/embedded/lib/libjemalloc.so
 

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,17 +1,5 @@
 #!/bin/bash -ex
 
-apt-get update
-apt-get install -y -q --no-install-recommends \
-  curl ca-certificates make g++ sudo bash
-
-/usr/bin/curl -sSL https://toolbelt.treasuredata.com/sh/install-ubuntu-xenial-td-agent3.sh | sh
-
-sed -i -e "s/USER=td-agent/USER=root/" -e "s/GROUP=td-agent/GROUP=root/" /etc/init.d/td-agent
-
-td-agent-gem install --no-document fluent-plugin-kubernetes_metadata_filter
-td-agent-gem install --no-document fluent-plugin-prometheus
-td-agent-gem install --no-document fluent-plugin-barito
-
 # Remove docs and postgres references
 rm -rf /opt/td-agent/embedded/share/doc \
   /opt/td-agent/embedded/share/gtk-doc \

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -ex
+
+td-agent-gem install --no-document fluent-plugin-kubernetes_metadata_filter
+td-agent-gem install --no-document fluent-plugin-prometheus
+td-agent-gem install --no-document fluent-plugin-barito

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+
+apt-get update
+apt-get install -y -q --no-install-recommends \
+  curl ca-certificates make g++ sudo bash
+
+/usr/bin/curl -sSL https://toolbelt.treasuredata.com/sh/install-ubuntu-xenial-td-agent4.sh | sh


### PR DESCRIPTION
changes:
- change td-agent version from 3 to 4
- split docker build step

Co-authored-by: Tara Baskara <tara.baskara@go-pay.co.id>