### PR TITLE
feat: introduce extraConfig variable

### DIFF
--- a/helm/charts/td-agent-barito/Chart.yaml
+++ b/helm/charts/td-agent-barito/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 name: td-agent-barito
 version: 0.2.21
 description: A Helm chart for Barito agent
-appVersion: 0.4.2
+appVersion: 0.4.3

--- a/helm/charts/td-agent-barito/templates/tdagentbaritoconfig.yaml
+++ b/helm/charts/td-agent-barito/templates/tdagentbaritoconfig.yaml
@@ -70,3 +70,7 @@ data:
       </buffer>
     </match>
     {{- end }}
+
+    {{- range .Values.extraConfig }}
+    {{ .config | nindent 4 }}
+    {{- end }}

--- a/helm/charts/td-agent-barito/values.yaml
+++ b/helm/charts/td-agent-barito/values.yaml
@@ -40,3 +40,23 @@ defaultAgentOptions:
     disableChunkBackup: true
 
 useCRIFormat: false
+
+extraConfig: {}
+  # - config: |-
+  #     <source>
+  #       @type tail
+  #       path           /var/log/messages
+  #       pos_file       /var/log/messages.pos
+  #       read_from_head true
+  #       tag            syslog
+  #       <parse>
+  #         @type regexp
+  #           expression  ^(?<time>[^ ]*.+[^ ]* [^ ]*) (?<host>[^ ]*) (?<process>[^ ]*): (?<message>.*)$
+  #           time_format %b  %d %H:%M:%S
+  #           time_key    time
+  #       </parse>
+  #     </source>
+
+  #     <match syslog>
+  #       @type stdout
+  #     </match>


### PR DESCRIPTION
### Introducing `extraConfig` variable

**Use case:**
At some point in self-managed Kubernetes, we need to pull the Kubelet log, however, the Kubelet log is only available on journal or file-based. In our use-case, we are hosting Kubelet log on the journal that is put in the `/var/log/messages` file. But the existing barito helm deployment is not able to customize configuration so that able to be put from other sources other than `/var/log/containers/*.log`.

This PR is meant to be able to do customize configuration in an ad hoc way.